### PR TITLE
Fix : Mode -k accept more param

### DIFF
--- a/source/command/ModeCommand.cpp
+++ b/source/command/ModeCommand.cpp
@@ -150,7 +150,7 @@ size_t	ModeCommand::CheckParamCount(const std::string& modestr) {
 				++count;
 		}
 		else if (sign == false) {
-			if (modestr[i] == 'o')
+			if (modestr[i] == 'o' || modestr[i] == 'k')
 				++count;
 		}
 	}


### PR DESCRIPTION
* Irssi 는, `mode -k ` 를 `mode -k password` 로 보냄. 이 경우 이전에는 bad params 로 처리했으나, 이를 허용하기로 함